### PR TITLE
std::lock_guard<std::mutex> lock(this->connectionListMutex);

### DIFF
--- a/server/WebsocketServer.cpp
+++ b/server/WebsocketServer.cpp
@@ -128,6 +128,8 @@ void WebsocketServer::onMessage(ClientConnection conn, WebsocketEndpoint::messag
 	Json::Value messageObject = WebsocketServer::parseJson(msg->get_payload());
 	if (messageObject.isNull() == false)
 	{
+		std::lock_guard<std::mutex> lock(this->connectionListMutex);
+		
 		// If any handlers are registered invoke them
 		for (auto handler : this->messageHandlers)
 		{


### PR DESCRIPTION
maybe fixes #2 / #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved thread safety for message handling in the WebSocket server, ensuring more reliable and stable operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->